### PR TITLE
Add Support for GitPod IDE

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -9,4 +9,4 @@ USER gitpod
 #
 # More information: https://www.gitpod.io/docs/config-docker/
 
-RUN sudo apt-get -q update && sudo apt-get install -yq libgl1-mesa-glx && sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get -q update && sudo apt-get install -yq libgl1-mesa-glx && sudo apt-get install -yq libasound2 && sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,12 @@
+FROM gitpod/workspace-full
+                    
+USER gitpod
+
+# Install custom tools, runtime, etc. using apt-get
+# For example, the command below would install "bastet" - a command line tetris clone:
+#
+# RUN sudo apt-get -q update && #     sudo apt-get install -yq bastet && #     sudo rm -rf /var/lib/apt/lists/*
+#
+# More information: https://www.gitpod.io/docs/config-docker/
+
+RUN sudo apt-get -q update && sudo apt-get install -yq libgl1-mesa-glx && sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,4 @@
+tasks:
+  - init: ./gradlew build
+image:
+  file: .gitpod.Dockerfile

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
 tasks:
-  - init: wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz && tar xvzf OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz && export JAVA_HOME=jdk-11.0.6+10 && ./gradlew build
+  - init: ./gradlew build
 image:
   file: .gitpod.Dockerfile

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
 tasks:
-  - init: ./gradlew build
+  - init: wget https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz && tar xvzf OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz && export JAVA_HOME=jdk-11.0.6+10 && ./gradlew build
 image:
   file: .gitpod.Dockerfile


### PR DESCRIPTION
Running JPRO in GitPod IDE does not work out of the box. This is due to some missing dependencies that have to be added to the underlying docker image. This PR adds two .gitpod* files which automatically configure the docker image correctly.